### PR TITLE
[PDF-9974] ci: auto-publish to Artifactory on tag push

### DIFF
--- a/.github/workflows/publish-on-tag.yml
+++ b/.github/workflows/publish-on-tag.yml
@@ -1,0 +1,18 @@
+name: Build & push to Artifactory
+
+# Automatically publishes this package to Artifactory (composer-local) whenever a
+# new tag is pushed. Reuses the shared, centrally-maintained publish workflow so the
+# publish logic lives in one place only (no per-repo duplication).
+# The manual "Republish old tags to Artifactory" action in airslateinc/everyday-automation
+# remains available for back-fill / exceptional cases.
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build-and-push:
+    uses: airslateinc/publish-composer-package/.github/workflows/workflow.yml@v1
+    secrets:
+      COMPOSER_TOKEN: ${{ secrets.COMPOSER_TOKEN }}


### PR DESCRIPTION
## What
Adds `.github/workflows/publish-on-tag.yml` — a thin caller that reuses the shared reusable workflow `airslateinc/publish-composer-package/.github/workflows/workflow.yml@v1` to publish this package to Artifactory (`composer-local`) automatically **whenever a new tag is pushed**.

## Why
Today a tag only lands in Artifactory after someone manually runs the *Republish old tags to Artifactory* action in `airslateinc/everyday-automation`. That is easy to forget. This automates it. See [PDF-9974](https://pdffiller.atlassian.net/browse/PDF-9974).

## Notes
- **No code duplication** — publish logic stays in the single shared reusable workflow; this repo only references it.
- Uses the org `COMPOSER_TOKEN` secret.
- The manual republish action is left untouched for back-fill / exceptional cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PDF-9974]: https://pdffiller.atlassian.net/browse/PDF-9974?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated publishing of the Composer package to Artifactory when a Git tag is created.
  * Standardized package publication through the shared release workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->